### PR TITLE
clone moment before applying timezone in amTimezone

### DIFF
--- a/angular-moment.js
+++ b/angular-moment.js
@@ -494,7 +494,7 @@
 					}
 
 					if (aMoment.tz) {
-						return aMoment.tz(timezone);
+						return aMoment.clone().tz(timezone);
 					} else {
 						$log.warn('angular-moment: named timezone specified but moment.tz() is undefined. Did you forget to include moment-timezone.js ?');
 						return aMoment;


### PR DESCRIPTION
Currently the amTimezone filter mutates the moment object before returning it.  This creates all sorts of subtle bugs if that moment is used later.

This patch clones the moment before applying the timezone to prevent this from happening.
